### PR TITLE
Update to plane.py to avoid divide by zero error

### DIFF
--- a/pyransac3d/plane.py
+++ b/pyransac3d/plane.py
@@ -53,6 +53,10 @@ class Plane:
 
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA, vecB)
+            
+            # if vectors A and B are pallel vector C will be a zero vector resulting in a divide by zero error in the next step
+            if np.any(vecC) == False:
+                continue
 
             # The plane equation will be vecC[0]*x + vecC[1]*y + vecC[0]*z = -k
             # We have to use a point to find k


### PR DESCRIPTION
Added a check for zero vector C after the cross product of vectors A and B are computed to prevent divide by zero error in the next step. Vector C will be a zero vector if vectors A and B are parallel. 