### PR TITLE
Fixed Divide by Zero Error in plane.py as a result of Parallel Vectors A and B

### DIFF
--- a/pyransac3d/circle.py
+++ b/pyransac3d/circle.py
@@ -61,6 +61,9 @@ class Circle:
 
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA_norm, vecB_norm)
+            # Avoid parallel vectors (division by zero error)
+            if np.any(vecC) == False:
+                continue
             vecC = vecC / np.linalg.norm(vecC)
 
             k = -np.sum(np.multiply(vecC, pt_samples[1, :]))

--- a/pyransac3d/cuboid.py
+++ b/pyransac3d/cuboid.py
@@ -55,6 +55,10 @@ class Cuboid:
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA, vecB)
 
+            # Avoid parallel vectors (division by zero error)
+            if np.any(vecC) == False:
+                continue
+
             # The plane equation will be vecC[0]*x + vecC[1]*y + vecC[0]*z = -k
             # We have to use a point to find k
             vecC = vecC / np.linalg.norm(vecC)  # Normal
@@ -79,6 +83,9 @@ class Cuboid:
             vecD = p4_proj_plane - pt_samples[3, :]
             vecE = pt_samples[4, :] - pt_samples[3, :]
             vecF = np.cross(vecD, vecE)
+            # Avoid parallel vectors (division by zero error)
+            if np.any(vecF) == False:
+                continue
             vecF = vecF / np.linalg.norm(vecF)  # Normal
             k = -np.sum(np.multiply(vecF, pt_samples[4, :]))
             plane_eq.append([vecF[0], vecF[1], vecF[2], k])

--- a/pyransac3d/cylinder.py
+++ b/pyransac3d/cylinder.py
@@ -62,6 +62,9 @@ class Cylinder:
 
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA_norm, vecB_norm)
+            # Avoid parallel vectors (division by zero error)
+            if np.any(vecC) == False:
+                continue
             vecC = vecC / np.linalg.norm(vecC)
 
             # Now we calculate the rotation of the points with rodrigues equation

--- a/pyransac3d/plane.py
+++ b/pyransac3d/plane.py
@@ -53,6 +53,10 @@ class Plane:
 
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA, vecB)
+            
+            # if vectors A and B are pallel vector C will be a zero vector resulting in a divide by zero error in the next step
+            if np.any(vecC) == False:
+                continue
 
             # The plane equation will be vecC[0]*x + vecC[1]*y + vecC[0]*z = -k
             # We have to use a point to find k

--- a/pyransac3d/plane.py
+++ b/pyransac3d/plane.py
@@ -54,7 +54,7 @@ class Plane:
             # Now we compute the cross product of vecA and vecB to get vecC which is normal to the plane
             vecC = np.cross(vecA, vecB)
             
-            # if vectors A and B are pallel vector C will be a zero vector resulting in a divide by zero error in the next step
+            # if vectors A and B are parallel vector C will be a zero vector resulting in a divide by zero error in the next step
             if np.any(vecC) == False:
                 continue
 


### PR DESCRIPTION
Added a check for zero vector C to prevent a divide by zero error in the next step after the cross product of vectors A and B are computed. If vectors A and B are parallel their cross product results in a zero vector C, causing the divide by zero error. 